### PR TITLE
Fix main script import path

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -2,8 +2,12 @@ import os
 import sys
 
 if __name__ == '__main__' and __package__ is None:
-    sys.path.insert(0, os.path.dirname(__file__))
-    from spec_corr3d import spec_corr3d
+    # When executed directly, ensure the project root is on sys.path so that
+    # imports using the package name ``python`` work correctly. This allows
+    # modules like ``spec_corr3d`` to resolve their relative imports.
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    sys.path.insert(0, repo_root)
+    from python.spec_corr3d import spec_corr3d
 else:
     from .spec_corr3d import spec_corr3d
 


### PR DESCRIPTION
## Summary
- ensure `python.main` loads modules using the `python` package when executed directly

## Testing
- `python python/main.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6869e804ae148329907065af785f705e