### PR TITLE
Fix main script import path

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -2,8 +2,12 @@ import os
 import sys
 
 if __name__ == '__main__' and __package__ is None:
-    sys.path.insert(0, os.path.dirname(__file__))
-    from spec_corr3d import spec_corr3d
+    # When executed directly, ensure the project root is on sys.path so that
+    # imports using the package name ``python`` work correctly. This allows
+    # modules like ``spec_corr3d`` to resolve their relative imports.
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    sys.path.insert(0, repo_root)
+    from python.spec_corr3d import spec_corr3d
 else:
     from .spec_corr3d import spec_corr3d
 

--- a/python/tps.py
+++ b/python/tps.py
@@ -33,11 +33,10 @@ def _update_transform(X, V, M, d, w, lam, dim, phi):
     N = X.shape[0]
     K = V.shape[0]
     Y = (M.dot(X)) / M.sum(axis=1)[:, None]
-    Y_aug = np.hstack([Y, np.ones((K, 1))])
     V_aug = np.hstack([V, np.ones((K, 1))])
     phi_l = phi + lam * np.eye(K)
     A = np.block([[phi_l, V_aug], [V_aug.T, np.zeros((dim + 1, dim + 1))]])
-    b = np.vstack([Y_aug, np.zeros((dim + 1, dim))])
+    b = np.vstack([Y, np.zeros((dim + 1, dim))])
     sol = np.linalg.lstsq(A, b, rcond=None)[0]
     w[:] = sol[:K]
     d[:] = sol[K:]


### PR DESCRIPTION
## Summary
- ensure `python.main` loads modules using the `python` package when executed directly
- fix TPS least squares setup to avoid dimension mismatch

## Testing
- `python -m py_compile python/*.py`
- `pytest -q` *(no tests found)*
- `python python/main.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6869e804ae148329907065af785f705e